### PR TITLE
[fix] 円グラフのスコア表示が90～100のときに灰色ではなく緑色になるようにする

### DIFF
--- a/frontend/src/app/components/circleProgressBar.tsx
+++ b/frontend/src/app/components/circleProgressBar.tsx
@@ -14,11 +14,17 @@ const CircularProgressBar = ({ maxValue, currentValue, size }: CircularProgressB
   const getProgressColor = (value: number) => {
     const percentage = (value / maxValue) * 100;
     if (percentage <= 50) {
+      // 0 ~ 50 : red
       return "rgb(239, 68, 68)";
     } else if (percentage <= 75) {
+      // 50 ~ 75 : yellow
       return "rgb(234, 179, 8)";
     } else if(percentage <= 90) {
+      // 75 ~ 90 : green
       return "rgb(34, 197, 94)";
+    } else if (percentage <= 100) {
+      // 90 ~ 100 : darkgreen
+      return "rgb(0, 128, 0)";
     }
   };
 


### PR DESCRIPTION
## 概要

プレイ画面の円グラフスコア表示が90～100のときに灰色に着色されるが、これを緑色になるように変更する

## 関連Issue

#32 

## 変更内容
<!-- 変更内容を箇条書きで記載 -->

## 動作確認方法
<!-- 動作確認の手順を記載 -->

## その他
<!-- その他、特記事項があれば記載 -->
