### PR TITLE
feat: 開発環境用のdocker-compose-dev.ymlを用意して、開発しやすいようにする

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,70 @@
+version: "3.8"
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - backend
+    networks:
+      - app-network
+
+  backend:
+    env_file:
+      - .env
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      PYTHONUNBUFFERED: 1
+      MONGO_USER: ${MONGO_USER}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: challenges_db
+      PASS_INITIALIZE_MONGO_SETUP: "False"
+    depends_on:
+      mongodb: # `mongodb`というネームでサービスを指定できるようにする
+        condition: service_healthy # `mongodb`サービスが正常に動作している場合のみ起動する
+    networks:
+      - app-network
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "${NGINX_EXTERNAL_PORT}:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - frontend
+      - backend
+    networks:
+      - app-network
+
+  mongodb:
+    image: mongo:latest
+    env_file:
+      - .env
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: challenges_db
+    volumes:
+      - mongodb_data:/data/db
+      - ./mongodb/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    networks:
+      - app-network
+    restart: on-failure
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+
+networks:
+  app-network:
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
## 概要

現状の開発環境では、ホットリロードを使おうと思えばフロントエンド・バックエンド両方を開発モードで起動しなければならないため手間が多い。それをdocker-composeにまとめることで簡略化したい。

## 関連Issue
<!-- 関連するIssue番号を記載 -->

## 変更内容
<!-- 変更内容を箇条書きで記載 -->

## 動作確認方法
<!-- 動作確認の手順を記載 -->

## その他
<!-- その他、特記事項があれば記載 -->
